### PR TITLE
Add postgres profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,10 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 		</dependency>

--- a/src/main/resources/application-postgres.properties
+++ b/src/main/resources/application-postgres.properties
@@ -1,0 +1,9 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/activitidb
+spring.datasource.driverClassName=org.postgresql.Driver
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
+spring.jpa.properties.hibernate.connection.provider_disables_autocommit=true
+spring.datasource.hikari.auto-commit=false


### PR DESCRIPTION
By applying the following program arguments, we can use postgresql as modeling app data store.
`--spring.profiles.active=postgres`